### PR TITLE
Test that fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 # symlinks to executables
 /experiment
 /snippet
+/check

--- a/lib/Core/Program.hs
+++ b/lib/Core/Program.hs
@@ -21,6 +21,7 @@ A top-level Program type giving you unified access to logging, concurrency,
 and more.
 -}
         module Core.Program.Execute
+      , module Core.Program.Unlift
 
         {-* Command-line argument parsing -}
 {-|
@@ -39,4 +40,5 @@ Facilities for noting events through your program and doing debugging.
 import Core.Program.Arguments
 import Core.Program.Logging
 import Core.Program.Execute
+import Core.Program.Unlift
 

--- a/lib/Core/Program/Context.hs
+++ b/lib/Core/Program/Context.hs
@@ -7,7 +7,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_HADDOCK hide #-}
 
--- This is an Internal module
+-- This is an Internal module, hidden from Haddock
 module Core.Program.Context
     ( 
         Context(..)
@@ -17,6 +17,8 @@ module Core.Program.Context
       , Message(..)
       , Verbosity(..)
       , Program(..)
+      , getContext
+      , subProgram
       , getConsoleWidth
     ) where
 
@@ -156,6 +158,23 @@ from test suites and example snippets.
 -}
 newtype Program τ α = Program (ReaderT (Context τ) IO α)
     deriving (Functor, Applicative, Monad, MonadIO, MonadReader (Context τ))
+
+{-|
+Get the internal @Context@ of the running @Program@. There is ordinarily no
+reason to use this; to access your top-level application data @τ@ within
+the @Context@ use 'Core.Program.Execute.getApplicationState'.
+-}
+getContext :: Program τ (Context τ)
+getContext = do
+    context <- ask
+    return context
+
+{-|
+Run a subprogram from within a lifted @IO@ block.
+-}
+subProgram :: Context τ -> Program τ α -> IO α
+subProgram context (Program reader) = do
+    runReaderT reader context
 
 --
 -- This is complicated. The **safe-exceptions** library exports a

--- a/lib/Core/Program/Context.hs
+++ b/lib/Core/Program/Context.hs
@@ -173,8 +173,8 @@ getContext = do
 Run a subprogram from within a lifted @IO@ block.
 -}
 subProgram :: Context τ -> Program τ α -> IO α
-subProgram context (Program reader) = do
-    runReaderT reader context
+subProgram context (Program r) = do
+    runReaderT r context
 
 --
 -- This is complicated. The **safe-exceptions** library exports a

--- a/lib/Core/Program/Context.hs
+++ b/lib/Core/Program/Context.hs
@@ -182,7 +182,7 @@ subProgram context (Program r) = do
 -- See https://github.com/fpco/safe-exceptions/issues/31 for
 -- discussion. In any event, the re-exports flow back to
 -- Control.Monad.Catch from **exceptions** and Control.Exceptions in
--- **base**. In _this_ module, we need to catch everything (including
+-- **base**. In the execute actions, we need to catch everything (including
 -- asynchronous exceptions); elsewhere we will use and wrap/export
 -- **safe-exceptions**'s variants of the functions.
 --

--- a/lib/Core/Program/Context.hs
+++ b/lib/Core/Program/Context.hs
@@ -28,8 +28,8 @@ import Chrono.TimeStamp (TimeStamp, getCurrentTimeNanoseconds)
 import Control.Concurrent.MVar (MVar, newMVar, newEmptyMVar)
 import Control.Concurrent.STM.TQueue (TQueue, newTQueueIO)
 import Control.Exception.Safe (displayException)
-import qualified Control.Exception.Safe as Safe (throw)
-import Control.Monad.Catch (MonadThrow(throwM), MonadCatch)
+import qualified Control.Exception.Safe as Safe (throw, catch)
+import Control.Monad.Catch (MonadThrow(throwM), MonadCatch(catch))
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader.Class (MonadReader(..))
 import Control.Monad.Trans.Reader (ReaderT(..))
@@ -42,7 +42,7 @@ import qualified System.Console.Terminal.Size as Terminal (Window(..), size)
 import System.Environment (getArgs, getProgName, lookupEnv)
 import System.Exit (ExitCode(..), exitWith)
 
-import Core.System.Base
+import Core.System.Base hiding (throw, catch)
 import Core.Text.Rope
 import Core.Program.Arguments
 
@@ -190,7 +190,8 @@ subProgram context (Program r) = do
 instance MonadThrow (Program τ) where
     throwM = liftIO . Safe.throw
 
-deriving instance MonadCatch (Program τ)
+instance MonadCatch (Program τ) where
+    catch = Safe.catch
 
 
 {-|

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -111,7 +111,6 @@ import Core.Program.Context
 import Core.Program.Logging
 import Core.Program.Signal
 import Core.Program.Arguments
-import Core.Program.Unlift
 
 unProgram :: Program τ α -> ReaderT (Context τ) IO α
 unProgram (Program reader) = reader

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -97,7 +97,7 @@ import Control.Monad (when, forever)
 import Control.Monad.Catch (Handler(..))
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader.Class (MonadReader(ask))
-import Control.Monad.Trans.Reader (ReaderT(runReaderT))
+import Control.Monad.Trans.Reader (ReaderT)
 import qualified Data.ByteString as B (hPut)
 import qualified Data.ByteString.Char8 as C (singleton)
 import GHC.Conc (numCapabilities, getNumProcessors, setNumCapabilities)
@@ -113,7 +113,7 @@ import Core.Program.Signal
 import Core.Program.Arguments
 
 unProgram :: Program τ α -> ReaderT (Context τ) IO α
-unProgram (Program reader) = reader
+unProgram (Program r) = r
 
 
 -- execute actual "main"

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -478,6 +478,110 @@ getContext = do
     context <- ask
     return context
 
+{-|
+The 'Program' monad is an instance of 'MonadIO', which makes sense; it's
+just a wrapper around doing 'IO' and you call it using 'execute' from the
+top-level @main@ action that is the entrypoint to any program.  So when you
+need to actually do some I/O or interact with other major libraries in the
+Haskell ecosystem, you need to get back to 'IO' and you use 'liftIO' to do
+it:
+
+@
+main :: 'IO' ()
+main = 'execute' $ do
+    -- now in the Program monad
+    'write' "Hello there"
+
+    'liftIO' $ do
+        -- do something in IO
+        source <- readFile "hello.c"
+        compileSourceCode source
+
+    -- back in Program monad
+    'write' \"Finished\"
+@
+
+and this is a perfectly reasonably pattern.
+
+Sometimes, however, you want to somehow get back to the 'Program' monad
+from there, and that's tricky; you can't just 'execute' a new program (and
+don't try: we've already initialized output and logging channels, signal
+handlers, your application context, etc).
+
+@
+main :: 'IO' ()
+main = 'execute' $ do
+    -- now in the Program monad
+    'write' "Hello there"
+
+    'liftIO' $ do
+        -- do something in IO
+        source <- readFile "hello.c"
+        -- log that we're starting compile      ... how???
+        result <- compileSourceCode source
+        case result of
+            Right object -> linkObjectCode object
+            Left err     -> -- debug the error  ... how???
+
+    -- back in Program monad
+    'write' \"Finished\"
+@
+
+We have a problem, because we'd like to do is use, say, 'debug' to log the
+compiler error, but we have no way to unlift back out of 'IO' to get to the
+'Program' monad.
+
+To workaround this, we offer 'withContext'. It gives you a function that
+you can use within your lifted 'IO' to run a 'Program' action.
+
+@
+    'withContext' $ \\runProgram -> do
+        action              :: IO
+        action              :: IO
+        runProgram ...      :: Program -> IO
+        action              :: IO
+@
+
+Think of this as 'liftIO' with an escape hatch.
+
+The type signature of this function is a bit involved, but this example
+shows that the lambda gives you a /function/ as its argument (we recommend
+you name it @runProgram@ for consistency) which gives you a way to run a
+subprogram, be that a single action like writing to terminal or logging, or
+a larger action in a do-notation block:
+
+@
+main :: 'IO' ()
+main = 'execute' $ do
+    -- now in the Program monad
+    'write' "Hello there"
+
+    'withContext' $ \\runProgram -> do
+        -- do something in IO
+        source <- readFile "hello.c"
+
+        runProgram $ do
+            -- now in Program monad
+            'event' \"Starting compile...\"
+            'event' \"Nah. Changed our minds\"
+            'event' \"Ok, fine, compile the thing\"
+
+        -- more IO
+        result <- compileSourceCode source
+        case result of
+            'Right' object -> linkObjectCode object
+            'Left' err     -> runProgram ('debugS' err)
+
+    -- back in Program monad
+    'write' \"Finished\"
+@
+
+Sometimes Haskell type inference can give you trouble because it tends to
+assume you mean what you say with the last statement of do-notation block.
+If you've got the type wrong you'll get an error, but in an odd place,
+probably at the top. This can be confusing. If you're having trouble with
+the types try putting @return ()@ at the end of your subprogram.
+-}
 -- I think I just discovered the same pattern as **unliftio**? Certainly
 -- the signature is similar. I'm not sure if there is any benefit to
 -- restating this as a `withRunInIO` action; we're deliberately trying to

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -80,9 +80,6 @@ module Core.Program.Execute
       , isNone
       , unProgram
       , unThread
-      , withContext
-      , getContext
-      , subProgram
     ) where
 
 import Prelude hiding (log)
@@ -114,16 +111,10 @@ import Core.Program.Context
 import Core.Program.Logging
 import Core.Program.Signal
 import Core.Program.Arguments
+import Core.Program.Unlift
 
 unProgram :: Program τ α -> ReaderT (Context τ) IO α
 unProgram (Program reader) = reader
-
-{-|
-Run a subprogram from within a lifted 'IO' block.
--}
-subProgram :: Context τ -> Program τ α -> IO α
-subProgram context (Program reader) = do
-    runReaderT reader context
 
 
 -- execute actual "main"
@@ -475,140 +466,3 @@ getCommandLine :: Program τ (Parameters)
 getCommandLine = do
     context <- ask
     return (commandLineFrom context)
-
-{-|
-Get the internal @Context@ of the running @Program@.
--}
-getContext :: Program τ (Context τ)
-getContext = do
-    context <- ask
-    return context
-
-{-|
-The 'Program' monad is an instance of 'MonadIO', which makes sense; it's
-just a wrapper around doing 'IO' and you call it using 'execute' from the
-top-level @main@ action that is the entrypoint to any program.  So when you
-need to actually do some I/O or interact with other major libraries in the
-Haskell ecosystem, you need to get back to 'IO' and you use 'liftIO' to do
-it:
-
-@
-main :: 'IO' ()
-main = 'execute' $ do
-    -- now in the Program monad
-    'write' "Hello there"
-
-    'liftIO' $ do
-        -- do something in IO
-        source <- readFile "hello.c"
-        compileSourceCode source
-
-    -- back in Program monad
-    'write' \"Finished\"
-@
-
-and this is a perfectly reasonably pattern.
-
-Sometimes, however, you want to somehow get back to the 'Program' monad
-from there, and that's tricky; you can't just 'execute' a new program (and
-don't try: we've already initialized output and logging channels, signal
-handlers, your application context, etc).
-
-@
-main :: 'IO' ()
-main = 'execute' $ do
-    -- now in the Program monad
-    'write' "Hello there"
-
-    'liftIO' $ do
-        -- do something in IO
-        source <- readFile "hello.c"
-        -- log that we're starting compile      ... how???
-        result <- compileSourceCode source
-        case result of
-            Right object -> linkObjectCode object
-            Left err     -> -- debug the error  ... how???
-
-    -- back in Program monad
-    'write' \"Finished\"
-@
-
-We have a problem, because we'd like to do is use, say, 'debug' to log the
-compiler error, but we have no way to unlift back out of 'IO' to get to the
-'Program' monad.
-
-To workaround this, we offer 'withContext'. It gives you a function that
-you can use within your lifted 'IO' to run a 'Program' action.
-
-@
-    'withContext' $ \\runProgram -> do
-        action              :: IO
-        action              :: IO
-        runProgram ...      :: Program -> IO
-        action              :: IO
-@
-
-Think of this as 'liftIO' with an escape hatch.
-
-The type signature of this function is a bit involved, but this example
-shows that the lambda gives you a /function/ as its argument (we recommend
-you name it @runProgram@ for consistency) which gives you a way to run a
-subprogram, be that a single action like writing to terminal or logging, or
-a larger action in a do-notation block:
-
-@
-main :: 'IO' ()
-main = 'execute' $ do
-    -- now in the Program monad
-    'write' "Hello there"
-
-    'withContext' $ \\runProgram -> do
-        -- do something in IO
-        source <- readFile "hello.c"
-
-        runProgram $ do
-            -- now in Program monad
-            'event' \"Starting compile...\"
-            'event' \"Nah. Changed our minds\"
-            'event' \"Ok, fine, compile the thing\"
-
-        -- more IO
-        result <- compileSourceCode source
-        case result of
-            'Right' object -> linkObjectCode object
-            'Left' err     -> runProgram ('debugS' err)
-
-    -- back in Program monad
-    'write' \"Finished\"
-@
-
-Sometimes Haskell type inference can give you trouble because it tends to
-assume you mean what you say with the last statement of do-notation block.
-If you've got the type wrong you'll get an error, but in an odd place,
-probably at the top. This can be confusing. If you're having trouble with
-the types try putting @return ()@ at the end of your subprogram.
-
-This function is named 'withContext' because it is a convenience around the
-following pattern:
-
-@
-    context <- 'getContext'
-    liftIO $ do
-        ...
-        'subProgram' context $ do
-            -- now in Program monad
-        ...
-@
--}
--- I think I just discovered the same pattern as **unliftio**? Certainly
--- the signature is similar. I'm not sure if there is any benefit to
--- restating this as a `withRunInIO` action; we're deliberately trying to
--- constrain the types.
-withContext
-    :: ((forall β. Program τ β -> IO β) -> IO α)
-    -> Program τ α
-withContext action = do
-    context <- getContext
-    let runThing = subProgram context
-    liftIO (action runThing)
-

--- a/lib/Core/Program/Execute.hs
+++ b/lib/Core/Program/Execute.hs
@@ -79,10 +79,10 @@ module Core.Program.Execute
       , None(..)
       , isNone
       , unProgram
-      , getContext
-      , subProgram
       , unThread
       , withContext
+      , getContext
+      , subProgram
     ) where
 
 import Prelude hiding (log)
@@ -118,7 +118,10 @@ import Core.Program.Arguments
 unProgram :: Program τ α -> ReaderT (Context τ) IO α
 unProgram (Program reader) = reader
 
-subProgram :: Context τ -> Program τ a -> IO a
+{-|
+Run a subprogram from within a lifted 'IO' block.
+-}
+subProgram :: Context τ -> Program τ α -> IO α
 subProgram context (Program reader) = do
     runReaderT reader context
 
@@ -473,6 +476,9 @@ getCommandLine = do
     context <- ask
     return (commandLineFrom context)
 
+{-|
+Get the internal @Context@ of the running @Program@.
+-}
 getContext :: Program τ (Context τ)
 getContext = do
     context <- ask
@@ -581,6 +587,18 @@ assume you mean what you say with the last statement of do-notation block.
 If you've got the type wrong you'll get an error, but in an odd place,
 probably at the top. This can be confusing. If you're having trouble with
 the types try putting @return ()@ at the end of your subprogram.
+
+This function is named 'withContext' because it is a convenience around the
+following pattern:
+
+@
+    context <- 'getContext'
+    liftIO $ do
+        ...
+        'subProgram' context $ do
+            -- now in Program monad
+        ...
+@
 -}
 -- I think I just discovered the same pattern as **unliftio**? Certainly
 -- the signature is similar. I'm not sure if there is any benefit to

--- a/lib/Core/Program/Unlift.hs
+++ b/lib/Core/Program/Unlift.hs
@@ -1,0 +1,174 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+{-|
+The 'Program' monad is an instance of 'MonadIO', which makes sense; it's
+just a wrapper around doing 'IO' and you call it using 'execute' from the
+top-level @main@ action that is the entrypoint to any program.  So when you
+need to actually do some I/O or interact with other major libraries in the
+Haskell ecosystem, you need to get back to 'IO' and you use 'liftIO' to do
+it:
+
+@
+main :: 'IO' ()
+main = 'execute' $ do
+    -- now in the Program monad
+    'write' "Hello there"
+
+    'liftIO' $ do
+        -- do something in IO
+        source <- readFile "hello.c"
+        compileSourceCode source
+
+    -- back in Program monad
+    'write' \"Finished\"
+@
+
+and this is a perfectly reasonably pattern.
+
+Sometimes, however, you want to somehow get back to the 'Program' monad
+from there, and that's tricky; you can't just 'execute' a new program (and
+don't try: we've already initialized output and logging channels, signal
+handlers, your application context, etc).
+
+@
+main :: 'IO' ()
+main = 'execute' $ do
+    -- now in the Program monad
+    'write' "Hello there"
+
+    'liftIO' $ do
+        -- do something in IO
+        source <- readFile "hello.c"
+        -- log that we're starting compile      ... how???
+        result <- compileSourceCode source
+        case result of
+            Right object -> linkObjectCode object
+            Left err     -> -- debug the error  ... how???
+
+    -- back in Program monad
+    'write' \"Finished\"
+@
+
+We have a problem, because we'd like to do is use, say, 'debug' to log the
+compiler error, but we have no way to unlift back out of 'IO' to get to the
+'Program' monad.
+
+To workaround this, we offer 'withContext'. It gives you a function that
+you can use within your lifted 'IO' to run a 'Program' action:
+
+@
+main :: 'IO' ()
+main = 'execute' $ do
+    -- now in the Program monad
+    'write' "Hello there"
+
+    'withContext' $ \\runProgram -> do
+        -- do something in IO
+        source <- readFile "hello.c"
+
+        runProgram $ do
+            -- now in Program monad
+            'event' \"Starting compile...\"
+            'event' \"Nah. Changed our minds\"
+            'event' \"Ok, fine, compile the thing\"
+
+        -- more IO
+        result <- compileSourceCode source
+        case result of
+            'Right' object -> linkObjectCode object
+            'Left' err     -> runProgram ('debugS' err)
+
+    -- back in Program monad
+    'write' \"Finished\"
+@
+
+Sometimes Haskell type inference can give you trouble because it tends to
+assume you mean what you say with the last statement of do-notation block.
+If you've got the type wrong you'll get an error, but in an odd place,
+probably at the top. This can be confusing. If you're having trouble with
+the types try putting @return ()@ at the end of your subprogram.
+-}
+module Core.Program.Unlift
+    (
+        {-* Useful actions -}
+        withContext
+        {-* Internals -}
+      , getContext
+      , subProgram
+    ) where
+
+import Control.Monad.Reader.Class (MonadReader(ask))
+import Control.Monad.Trans.Reader (ReaderT(runReaderT))
+
+import Core.Program.Context
+import Core.System.Base
+
+{-|
+Get the internal @Context@ of the running @Program@.
+-}
+getContext :: Program τ (Context τ)
+getContext = do
+    context <- ask
+    return context
+
+{-|
+Run a subprogram from within a lifted 'IO' block.
+-}
+subProgram :: Context τ -> Program τ α -> IO α
+subProgram context (Program reader) = do
+    runReaderT reader context
+
+{-|
+This gives you a function that you can use within your lifted 'IO' actions
+to return to the 'Program' monad.
+
+The type signature of this function is a bit involved, but this example
+shows that the lambda gives you a /function/ as its argument (we recommend
+you name it @__runProgram__@ for consistency) which gives you a way to run a
+subprogram, be that a single action like writing to terminal or logging, or
+a larger action in a do-notation block:
+
+@
+main :: IO ()
+main = execute $ do
+    'withContext' $ \\runProgram -> do
+        -- in IO monad, lifted
+        -- (just as if you had used liftIO)
+
+        ...
+
+        __runProgram__ $ do
+            -- now unlifted, back to Program monad
+
+        ...
+@
+
+Think of this as 'liftIO' with an escape hatch.
+
+This function is named 'withContext' because it is a convenience around the
+following pattern:
+
+@
+    context <- 'getContext'
+    liftIO $ do
+        ...
+        'subProgram' context $ do
+            -- now in Program monad
+        ...
+@
+-}
+-- I think I just discovered the same pattern as **unliftio**? Certainly
+-- the signature is similar. I'm not sure if there is any benefit to
+-- restating this as a `withRunInIO` action; we're deliberately trying to
+-- constrain the types.
+withContext
+    :: ((forall β. Program τ β -> IO β) -> IO α)
+    -> Program τ α
+withContext action = do
+    context <- getContext
+    let runThing = subProgram context
+    liftIO (action runThing)
+

--- a/lib/Core/Program/Unlift.hs
+++ b/lib/Core/Program/Unlift.hs
@@ -108,23 +108,6 @@ import Core.Program.Context
 import Core.System.Base
 
 {-|
-Get the internal @Context@ of the running @Program@. There is ordinarily no
-reason to use this; to access your top-level application data @τ@ within
-the @Context@ use 'Core.Program.Execute.getApplicationState'.
--}
-getContext :: Program τ (Context τ)
-getContext = do
-    context <- ask
-    return context
-
-{-|
-Run a subprogram from within a lifted @IO@ block.
--}
-subProgram :: Context τ -> Program τ α -> IO α
-subProgram context (Program reader) = do
-    runReaderT reader context
-
-{-|
 This gives you a function that you can use within your lifted 'IO' actions
 to return to the 'Program' monad.
 

--- a/lib/Core/System/Base.hs
+++ b/lib/Core/System/Base.hs
@@ -10,6 +10,7 @@ module Core.System.Base
       {-** from Control.Monad.IO.Class -}
       {-| Re-exported from "Control.Monad.IO.Class" in __base__: -}
       liftIO
+    , MonadIO
       {-** from System.IO -}
       {-| Re-exported from "System.IO" in __base__: -}
     , Handle
@@ -26,7 +27,7 @@ module Core.System.Base
     ) where
 
 import Control.Exception.Safe (Exception(..), throw, bracket, catch)
-import Control.Monad.IO.Class (liftIO)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import System.IO (Handle, stdin, stdout, stderr, hFlush)
 import System.IO.Unsafe (unsafePerformIO)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.4.6
+version: 0.4.7
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -53,6 +53,7 @@ library:
    - Core.Program.Arguments
    - Core.Program.Execute
    - Core.Program.Logging
+   - Core.Program.Unlift
   other-modules:
    - Core.Program.Context
    - Core.Program.Signal

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.4.5
+version: 0.4.6
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/path
+++ b/path
@@ -1,19 +1,39 @@
 #!/bin/sh
 
-BINDIR=`stack path --local-install-root`/bin
+set -x
+
+ROOTDIR=`stack path --local-install-root`
+DISTDIR=`stack path --dist-dir`
 
 link () {
-	NAME="$1"
+	NAME="$2"
+	ORIGIN="$1"
 
 	if [ -L ./${NAME} ] ; then
 		rm -f ./${NAME}
 	fi
 	if [ -f ./${NAME} ] ; then
-		exit
+		exit 1
 	fi
-	ln -s ${BINDIR}/${NAME} ${NAME}
+	ln -s ${ORIGIN} ${NAME}
 }
 
-link snippet
-link experiment
+# symlink a "executable" binary
+e () {
+	NAME="$1"
+	ln -s "${ROOTDIR}/bin/${NAME}" "${NAME}"
+}
+
+# symlink a "test-suite" binary
+t () {
+	NAME="$1"
+	link "${DISTDIR}/build/${NAME}/${NAME}" "${NAME}"
+}
+
+
+# main
+e experiment
+t check
+t snippet
+
 

--- a/tests/CheckProgramMonad.hs
+++ b/tests/CheckProgramMonad.hs
@@ -4,6 +4,7 @@
 
 module CheckProgramMonad where
 
+import qualified Control.Exception.Safe as Safe
 import Test.Hspec hiding (context)
 
 import Core.Program.Arguments
@@ -76,6 +77,11 @@ checkProgramMonad = do
             -- ok, so with that established, now try **safe-exceptions**'s
             -- code. Note if we move the exception handling code from
             -- `execute` to `subProgram` this will have to adapt.
-            catch
+            Safe.catch
                 (subProgram context (throw Boom))
                 (\(e :: Boom) -> return ())
+
+        it "MonadThrow and MonadCatch behave" $ do
+            context <- configure None blank
+            subProgram context $ do
+                Safe.catch (Safe.throw Boom) (\(e :: Boom) -> return ())

--- a/tests/CheckProgramMonad.hs
+++ b/tests/CheckProgramMonad.hs
@@ -1,18 +1,21 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# LANGUAGE OverloadedLists #-}
 
 module CheckProgramMonad where
 
-import Test.Hspec
+import Test.Hspec hiding (context)
 
 import Core.Program.Arguments
 import Core.Program.Execute
 import Core.Program.Unlift
+import Core.System.Base
 
+options :: [Options]
 options =
     [ Option "all" (Just 'a') "Good will to everyone"
     ]
 
+commands :: [Commands]
 commands =
     [ Global
         options
@@ -25,3 +28,25 @@ checkProgramMonad = do
     describe "Context type" $ do
         it "Eq instance for None behaves" $
             None `shouldBe` None
+
+    describe "Program monad" $ do
+        it "execute with blank Context as expected" $ do
+            context <- configure None blank
+            executeWith context $ do
+                user <- getApplicationState
+                liftIO $ do
+                    user `shouldBe` None
+
+        it "execute with simple Context as expected" $ do
+            context <- configure None (simple options)
+            executeWith context $ do
+                params <- getCommandLine
+                liftIO $ do
+                    -- this assumes that hspec isn't passing any
+                    -- command-line arguments through to us.
+                    params `shouldBe` (Parameters Nothing [] [])
+
+        it "sub-programs can be run" $ do
+            context <- configure None blank
+            result <- subProgram context (getApplicationState)
+            result `shouldBe` None

--- a/tests/CheckProgramMonad.hs
+++ b/tests/CheckProgramMonad.hs
@@ -7,6 +7,7 @@ import Test.Hspec
 
 import Core.Program.Arguments
 import Core.Program.Execute
+import Core.Program.Unlift
 
 options =
     [ Option "all" (Just 'a') "Good will to everyone"

--- a/tests/CheckProgramMonad.hs
+++ b/tests/CheckProgramMonad.hs
@@ -46,7 +46,16 @@ checkProgramMonad = do
                     -- command-line arguments through to us.
                     params `shouldBe` (Parameters Nothing [] [])
 
+        -- not strictly necessary but sets up next spec item
         it "sub-programs can be run" $ do
             context <- configure None blank
-            result <- subProgram context (getApplicationState)
-            result `shouldBe` None
+            user <- subProgram context (getApplicationState)
+            user `shouldBe` None
+
+        it "unlifting from lifted IO works" $
+            execute $ do
+                user1 <- getApplicationState
+                withContext $ \runProgram -> do
+                    user1 `shouldBe` None
+                    user2 <- runProgram getApplicationState -- unlift!
+                    user2 `shouldBe` user1


### PR DESCRIPTION
I wrote some test cases to cover `subProgram` and `withContext` (they're merged to `'master'` already, suggest you pull into your branch) to enable me to try this.

I then wrote a test (commit a65d799) for the MonadThrow/MonadCatch instance and it fails ... badly. In attempting to use the MonadCatch's `catch` method the program appears to go into a busy loop that pins the CPU. Weird.